### PR TITLE
feat: change file-loader chunkhash to hash

### DIFF
--- a/src/webpack.common.js
+++ b/src/webpack.common.js
@@ -379,7 +379,7 @@ const browserConfig = function(options, root, settings) {
          */
         {
           test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
-          use: 'file-loader?name=assets/[name].[chunkhash].[ext]'
+          use: 'file-loader?name=assets/[name].[hash].[ext]'
         }
       ]
     },


### PR DESCRIPTION
(possibly temporary) quick-fix to allow relative-path referencing of assets. Helps with [issue#36](https://github.com/ng-seed/universal/issues/14) and [issue#14](https://github.com/ng-seed/universal/issues/36).

`hash` uses  hash of the file contents as opposed to the chunk so seems more sensible as well.