### PR TITLE
feat: added node_modules for scss loader

### DIFF
--- a/src/webpack.common.js
+++ b/src/webpack.common.js
@@ -347,7 +347,10 @@ const browserConfig = function(options, root, settings) {
          */
         {
           test: /\.scss$/,
-          include: root(settings.paths.src.client.app.root),
+          include: [
+              root(settings.paths.src.client.app.root),
+              root('node_modules')
+          ],
           use: [
             // TODO: temporarily disabled for sourcemaps interference
             // 'to-string-loader',


### PR DESCRIPTION
fixes issue where production build would fail of installed/included packages (in node_modules) contained scss files. Fixes [issue #38](https://github.com/ng-seed/universal/issues/38)